### PR TITLE
feat: Protect pages with /dashboard base path

### DIFF
--- a/app/(auth)/access/[token]/page.tsx
+++ b/app/(auth)/access/[token]/page.tsx
@@ -99,8 +99,9 @@ export default function AccessPage({
 							<div className="text-center">
 								<p className="text-xl font-medium">Falha na autenticação</p>
 								<p className="mt-1 text-muted-foreground">
-									{error ||
-										"O link de acesso é inválido ou expirou. Por favor, solicite um novo link."}
+									{
+										"O link de acesso é inválido ou expirou. Por favor, solicite um novo link."
+									}
 								</p>
 							</div>
 						</div>

--- a/app/(auth)/access/page.tsx
+++ b/app/(auth)/access/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AccessPage() {
+	redirect("/sign-up");
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,3 +1,55 @@
-export default function Page() {
-	return <p>Dashboard</p>;
+"use client";
+
+import { useCurrentUser } from "@/src/hooks/use-current-user";
+import { Loader2 } from "lucide-react";
+
+export default function DashboardPage() {
+	const { user, isLoading, isError, errorMessage } = useCurrentUser();
+
+	if (isLoading) {
+		return (
+			<div className="flex min-h-screen items-center justify-center">
+				<Loader2 className="h-8 w-8 animate-spin text-primary" />
+			</div>
+		);
+	}
+
+	if (isError) {
+		return (
+			<div className="flex min-h-screen items-center justify-center text-center">
+				<div>
+					<h1 className="text-2xl font-semibold text-destructive-foreground">
+						Ocorreu um erro inesperado
+					</h1>
+					<p className="mt-2 text-muted-foreground">{errorMessage}</p>
+					<p className="mt-4">
+						<a href="/sign-in" className="text-primary underline">
+							Faça login novamente
+						</a>
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="min-h-screen p-8">
+			<h1 className="text-3xl font-bold">
+				Bem-vindo ao Dashboard, {user?.name}!
+			</h1>
+			<div className="mt-4 space-y-2">
+				<p>
+					<strong>Email:</strong> {user?.email}
+				</p>
+				<p>
+					<strong>Role:</strong> {user?.role}
+				</p>
+				{user?.hotel && (
+					<p>
+						<strong>Hotel ID:</strong> {user?.hotel}
+					</p>
+				)}
+			</div>
+		</div>
+	);
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,51 @@
+import { getJwtPayloadFromCookies } from "@/src/lib/jwt";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import type { AccessTokenPayload } from "./src/types";
+
+export async function middleware(request: NextRequest) {
+	const { pathname } = request.nextUrl;
+
+	const protectedRoute = "/dashboard";
+	const isProtectedRoute = pathname.startsWith(protectedRoute);
+
+	const authRoutes = ["/sign-up", "/access"];
+	const isAuthRoute = authRoutes.some((route) =>
+		route === "/access"
+			? pathname.match(/^\/access\/[^/]+$/)
+			: pathname.startsWith(route),
+	);
+
+	let payload: AccessTokenPayload | null;
+	try {
+		payload = await getJwtPayloadFromCookies<AccessTokenPayload>();
+	} catch (error) {
+		payload = null;
+	}
+
+	if (isProtectedRoute) {
+		if (!payload) {
+			/**
+			 * @todo Replace "/sign-up" redirect URL once sign-up page is implemented
+			 */
+			const signInUrl = new URL("/sign-up", request.url);
+			signInUrl.searchParams.set("redirect", pathname);
+			return NextResponse.redirect(signInUrl);
+		}
+		return NextResponse.next();
+	}
+
+	if (isAuthRoute) {
+		if (payload) {
+			const dashboardUrl = new URL("/dashboard", request.url);
+			return NextResponse.redirect(dashboardUrl);
+		}
+		return NextResponse.next();
+	}
+
+	return NextResponse.next();
+}
+
+export const config = {
+	matcher: ["/dashboard/:path*", "/access/:path*", "/sign-up/:path*"],
+};

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 	},
 	"dependencies": {
 		"@hookform/resolvers": "^4.1.3",
+		"@paralleldrive/cuid2": "^2.2.2",
 		"@radix-ui/react-accordion": "^1.2.3",
 		"@radix-ui/react-alert-dialog": "^1.1.6",
 		"@radix-ui/react-aspect-ratio": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^4.1.3
         version: 4.1.3(react-hook-form@7.54.2(react@19.0.0))
+      '@paralleldrive/cuid2':
+        specifier: ^2.2.2
+        version: 2.2.2
       '@radix-ui/react-accordion':
         specifier: ^1.2.3
         version: 1.2.3(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -703,9 +706,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/hashes@1.7.1':
+    resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@paralleldrive/cuid2@2.2.2':
+    resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -3305,8 +3315,14 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.2.1':
     optional: true
 
+  '@noble/hashes@1.7.1': {}
+
   '@opentelemetry/api@1.9.0':
     optional: true
+
+  '@paralleldrive/cuid2@2.2.2':
+    dependencies:
+      '@noble/hashes': 1.7.1
 
   '@protobufjs/aspromise@1.1.2': {}
 

--- a/src/actions/consume-magic-link.ts
+++ b/src/actions/consume-magic-link.ts
@@ -6,7 +6,7 @@ import { database } from "../lib/database";
 import { encryptJwt, setJwtToken } from "../lib/jwt";
 import { redis } from "../lib/redis";
 import { UserModel } from "../models/user";
-import type { SignUpIntent } from "../types";
+import type { AccessTokenPayload, SignUpIntent } from "../types";
 
 export type MagicLinkOutput = {
 	id: string;
@@ -46,7 +46,11 @@ export const consumeMagicLink = buildAction(
 
 		const { id } = await user.save();
 
-		const jwtToken = await encryptJwt({ id, email, name: user.name });
+		const jwtToken = await encryptJwt({
+			id,
+			email,
+			name: user.name,
+		} satisfies AccessTokenPayload);
 		await setJwtToken(jwtToken);
 
 		return {

--- a/src/actions/get-current-user.ts
+++ b/src/actions/get-current-user.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import { UnauthorizedError } from "../errors";
+import { buildAction } from "../lib/action";
+import { database } from "../lib/database";
+import { getJwtPayloadFromCookies } from "../lib/jwt";
+import { UserModel, type UserRole } from "../models/user";
+
+export type GetCurrentUserOutput = {
+	id: string;
+	email: string;
+	name: string;
+	role: UserRole;
+	hotel?: string;
+};
+
+export const getCurrentUser = buildAction(
+	async (): Promise<GetCurrentUserOutput> => {
+		const payload = await getJwtPayloadFromCookies<{
+			id: string;
+			email: string;
+			name: string;
+		}>();
+
+		if (!payload) {
+			throw new UnauthorizedError("Usuário não autenticado.");
+		}
+
+		const { id } = payload;
+
+		await database.connect();
+
+		const user = await UserModel.findById(id).lean();
+		if (!user) {
+			throw new UnauthorizedError("Usuário não encontrado.");
+		}
+
+		return {
+			id: user._id.toString(),
+			email: user.email,
+			name: user.name,
+			role: user.role,
+			hotel: user.hotel?.toString(),
+		};
+	},
+);

--- a/src/actions/sign-up-with-google.ts
+++ b/src/actions/sign-up-with-google.ts
@@ -6,6 +6,7 @@ import { database } from "../lib/database";
 import { auth } from "../lib/firebase/admin";
 import { encryptJwt, setJwtToken } from "../lib/jwt";
 import { UserModel } from "../models/user";
+import type { AccessTokenPayload } from "../types";
 
 export type GoogleSignUpOutput = {
 	id: string;
@@ -57,7 +58,11 @@ export const signUpWithGoogle = buildAction(
 
 		const { id } = user;
 
-		const jwtToken = await encryptJwt({ id, email, name: user.name });
+		const jwtToken = await encryptJwt({
+			id,
+			email,
+			name: user.name,
+		} satisfies AccessTokenPayload);
 		await setJwtToken(jwtToken);
 
 		return {

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createId } from "@paralleldrive/cuid2";
 
 export interface HttpErrorOptions {
 	statusCode?: number;
@@ -32,7 +32,7 @@ export class HttpError extends Error {
 		this.status = options.status || "error";
 		this.details = options.details;
 		this.code = options.code;
-		this.correlationId = options.correlationId || randomUUID();
+		this.correlationId = options.correlationId || createId();
 
 		if (options.cause) {
 			this.stack = `${this.stack}\nCaused by: ${options.cause.stack}`;

--- a/src/hooks/use-current-user.ts
+++ b/src/hooks/use-current-user.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import {
+	type GetCurrentUserOutput,
+	getCurrentUser,
+} from "@/src/actions/get-current-user";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+export function useCurrentUser() {
+	const [user, setUser] = useState<GetCurrentUserOutput | null>(null);
+	const [isLoading, setIsLoading] = useState(true);
+	const [isError, setIsError] = useState(false);
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+	useEffect(() => {
+		let isMounted = true;
+
+		const fetchUser = async () => {
+			setIsLoading(true);
+			setIsError(false);
+			setErrorMessage(null);
+
+			try {
+				const response = await getCurrentUser();
+				if (isMounted) {
+					setUser(response.data);
+				}
+			} catch (error) {
+				if (isMounted) {
+					setIsError(true);
+					const message =
+						error instanceof Error
+							? error.message
+							: "Erro desconhecido ao carregar usuário.";
+					setErrorMessage(message);
+					toast.error("Erro ao carregar dados do usuário", {
+						description: message,
+					});
+				}
+			} finally {
+				if (isMounted) {
+					setIsLoading(false);
+				}
+			}
+		};
+
+		fetchUser();
+
+		return () => {
+			isMounted = false;
+		};
+	}, []);
+
+	return {
+		user,
+		isLoading,
+		isError,
+		errorMessage,
+	};
+}

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -100,3 +100,12 @@ export async function setJwtToken(
 
 	cookieStore.set(AUTH_COOKIE_NAME, token, finalOptions);
 }
+
+/**
+ * Clears the JWT token from cookies, effectively logging out the user.
+ * @returns Promise that resolves when the cookie is cleared
+ */
+export async function clearJwtFromCookies(): Promise<void> {
+	const cookieStore = await cookies();
+	cookieStore.delete(AUTH_COOKIE_NAME);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,3 +2,9 @@ export type SignUpIntent = {
 	name: string;
 	email: string;
 };
+
+export type AccessTokenPayload = {
+	id: string;
+	name: string;
+	email: string;
+};


### PR DESCRIPTION
- Add `getCurrentUser` server action and `useCurrentUser` hook for authenticated user fetching
- Add Next.js middleware to protect pages under /dashboard and redirect authenticated users
- Replaced node.js UUID usage in http errors to allow them being used in the middleware edge runtime